### PR TITLE
Fixes phantomas path

### DIFF
--- a/analyze.js
+++ b/analyze.js
@@ -14,7 +14,7 @@ var validate = require('./validate');
 function buildCommand(options){
   validate(options);
 
-  var command = __dirname + '/node_modules/.bin/phantomas ' + options.url;
+  var command = 'phantomas ' + options.url;
 
   command += ' --engine ' + options.engine;
   command += ' --runs ' + options.runs;

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   "author": "Avraam Mavridis",
   "license": "ISC",
   "dependencies": {
-    "cli-color": "^0.3.2",
-    "gulp-connect": "^2.2.0",
+    "cli-color": "^1.1.0",
+    "gulp-connect": "^5.0.0",
     "gulp-util": "^3.0.3",
     "joi": "^5.1.0",
     "phantomas": "^1.9.0"


### PR DESCRIPTION
Referencing the pull request identified by @theotherzach in issue #11, I reverted the changes made to line 17 of analyze.js. I was unable to find a way to reference a projects local phantomas instance, but for the time being this fixes the error when phantomas is installed globally.
