### PR TITLE
Changing the "results.json" to a file with the same of tested domain.

### DIFF
--- a/analyze.js
+++ b/analyze.js
@@ -30,15 +30,18 @@ function buildCommand(options){
 // Exucute and analyze the resuls
 // {options} object
 function analyze(options, callback){
+
   command = buildCommand(options);
 
-  exec(command + ' --reporter=json > results.json', function(error, stdout, stderr){
+  var outPutFileName = (options.url) ? options.url.replace(/^(https?|ftp):\/\//, '') + '.json' : 'results.json';
+
+  exec(command + ' --reporter=json > ' + outPutFileName, function(error, stdout, stderr){
     if(error !== null){
       console.log(error);
       return false;
     }
     else {
-        fs.readFile('results.json', function(error, data){
+        fs.readFile(outPutFileName, function(error, data){
 
           data = JSON.parse(data);
           metrics = data.metrics;


### PR DESCRIPTION
The idea is enable use gulp-louis to test several websites with a single script, to feed a dashboard for example. To do that I changes the results.json to a file with the name of target domain plus .json. 

example:

``` javascript
{
    timeout: 60,
    url: 'http://www.youtube.com',
    viewport: '1280x1024',
    engine: 'webkit',
    userAgent: 'Chrome/37.0.2062.120',
    noExternals: false,
    performanceBudget: {
      cssSize: 200,
      jsSize: 2000,
      consoleMessages: 0,
      imageSize: 5000,
      domContentLoaded: 2000,
      smallestLatency: 1000
    }
  }

```

the file result will be: www.youtube.com.json

With this small change it is possible do something like that:

``` javascript
  const urls = ['http://www.youtube.com', 'http://www.google.com', 'http://www.twitter.com'];

  let luisDefaults = {
    timeout: 60,
    url: '',
    viewport: '1280x1024',
    engine: 'webkit',
    userAgent: 'Chrome/37.0.2062.120',
    noExternals: false,
    performanceBudget: {
      cssSize: 200,
      jsSize: 2000,
      consoleMessages: 0,
      imageSize: 5000,
      domContentLoaded: 2000,
      smallestLatency: 1000
    }
  };

  urls.forEach((item) => {
    luisDefaults.url = item;
    louis(luisDefaults);
  });
```

And have several output files.
