### PR TITLE
Fix for external-option being directly behind other options

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,18 @@ The performance budget option can contain some or all of these values:
 
 ### Change log
 
+#### [2.3.0] - 2016-10-07
+
+- Added proxy-option
+
+#### [2.2.1] - 2016-09-29
+
+- Update dependencies
+
+#### [2.2.0] - 2016-09-29
+
+- Add outputFilename-option
+
 #### [2.1.1] - 2016-09-16
 
 - Update dependencies

--- a/analyze.js
+++ b/analyze.js
@@ -25,7 +25,7 @@ function buildCommand(options){
     command += ' --proxy ' + options.proxy;
 
   if(options.noExternals)
-    command += '--no-externals'
+    command += ' --no-externals';
 
   return command;
 }


### PR DESCRIPTION
Noticed it when using the new proxy option. Also updated the changelog
